### PR TITLE
fix: make `pytorch_ops` work on GPU

### DIFF
--- a/fast_soft_sort/pytorch_ops.py
+++ b/fast_soft_sort/pytorch_ops.py
@@ -31,13 +31,13 @@ def wrap_class(cls, **kwargs):
 
     @staticmethod
     def forward(ctx, values):
-      obj = cls(values.detach().numpy(), **kwargs)
+      obj = cls(values.detach().cpu().numpy(), **kwargs)
       ctx.numpy_obj = obj
-      return torch.from_numpy(obj.compute())
+      return torch.from_numpy(obj.compute()).to(values.device)
 
     @staticmethod
     def backward(ctx, grad_output):
-      return torch.from_numpy(ctx.numpy_obj.vjp(grad_output.numpy()))
+      return torch.from_numpy(ctx.numpy_obj.vjp(grad_output.cpu().numpy())).to(grad_output.device)
 
   return NumpyOpWrapper
 


### PR DESCRIPTION
This PR adds a small modification to the `NumpyOpWrapper` that is used in `pytorch_ops`, making the torch functions work with CUDA tensors. This should fix the following two issues:
- https://github.com/google-research/fast-soft-sort/issues/16
- https://github.com/google-research/fast-soft-sort/issues/18

We have to move the tensors from GPU to CPU and back to run the soft sorting and ranking in numpy. There's no way around that unfortunately.